### PR TITLE
Add support for selecting in both directions.

### DIFF
--- a/lib/expand-selection-to-indentation.js
+++ b/lib/expand-selection-to-indentation.js
@@ -36,7 +36,14 @@ class ExpandSelectionToIndentation {
     return leadingSpacesCount;
   }
 
-  up() {
+  /**
+   * Select lines with the same indentation in the given direction
+   *
+   * @param  {boolean}  upwards the direction in which to select.
+   */
+  up_or_down(upwards) {
+    // false => 1, true => -1
+    const direction = (1 - 2 * new Boolean(upwards))
     const editor = atom.workspace.getActiveTextEditor();
 
     const currentRow = editor.getCursorBufferPosition().row;
@@ -47,12 +54,12 @@ class ExpandSelectionToIndentation {
     log('Start at ', currentRow);
 
     let numberOfRowsToSelect = 0;
-    // Continue scanning rows of text upwards until we meet the same leading space count.
+    // Continue scanning rows of text until we meet the same leading space count.
     while (1) {
-      let lineIndex = currentRow - numberOfRowsToSelect - 1;
+      let lineIndex = currentRow + direction * (numberOfRowsToSelect + 1);
       let line = editor.lineTextForBufferRow(lineIndex);
       let spacesOnLine = this.numberOfLeadingSpacesInText(line);
-      if (spacesOnLine !== leadingSpacesCount || lineIndex === -1) {
+      if (spacesOnLine < leadingSpacesCount || lineIndex === -1 || lineIndex === 0) {
         log('Done adding rows, lineIndex: %d', lineIndex);
         break;
       }
@@ -60,33 +67,14 @@ class ExpandSelectionToIndentation {
       log('Add %s at %s', line, lineIndex);
     }
 
-    editor.selectUp(numberOfRowsToSelect);
-  }
-
-  down() {
-    const editor = atom.workspace.getActiveTextEditor();
-
-    const currentRow = editor.getCursorBufferPosition().row;
-    const leadingSpacesCount = this.numberOfLeadingSpacesInText(
-      editor.lineTextForBufferRow(currentRow),
-    );
-
-    console.log('going down until we find: %s', leadingSpacesCount);
-
-    let numberOfRowsToSelect = 0;
-    // Continue scanning rows of text upwards until we meet the same leading space count.
-    while (1) {
-      let lineIndex = currentRow + numberOfRowsToSelect + 1;
-      let line = editor.lineTextForBufferRow(lineIndex);
-      let spacesOnLine = this.numberOfLeadingSpacesInText(line);
-      if (spacesOnLine !== leadingSpacesCount || lineIndex === 0) {
-        break;
-      }
-      numberOfRowsToSelect++;
-      console.log('%s | %s', line, spacesOnLine);
-    }
+    if (upwards) editor.moveUp(numberOfRowsToSelect);
 
     editor.selectDown(numberOfRowsToSelect);
+  }
+
+  up_and_down() {
+    this.up_or_down(true);
+    this.up_or_down(false);
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,10 +14,13 @@ export default {
     this.subscriptions.add(
       atom.commands.add('atom-workspace', {
         'expand-selection-to-indentation:select-up': () => {
-          ExpandSelectionToIndentation.up();
+          ExpandSelectionToIndentation.up_or_down(true);
         },
         'expand-selection-to-indentation:select-down': () => {
-          ExpandSelectionToIndentation.down();
+          ExpandSelectionToIndentation.up_or_down(false);
+        },
+        'expand-selection-to-indentation:select-both': () => {
+          ExpandSelectionToIndentation.up_and_down();
         },
       }),
     );


### PR DESCRIPTION
Also make sure that the cursor is always at the end of the selection.

"Breaking" change: select all lines with indent _at least_ as large as the current one. This is the same as Sublime's `expand_selection {"to": "indentation"}`.

Wish list:
- expand selection to start and end on the start of lines, after running the command